### PR TITLE
More flexibility of Windows Julia version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ Icon^M
 .DS_Store
 Stable
 pipDeploy
+*.pyc
+*example*
+*.ipynb

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 
 ## What's new
 
-Quite of a new version, v4.0.0 introduce a lot of new stuff including: 
-- Complete recoding of the core with better codding and commenting which hopefully makes it easier to implement custom features 
+A major revision, v4.0.0 introduces a lot of new stuff including:
+- Complete recoding of the core with better coding and commenting which hopefully makes it easier to implement custom features
 - Modification of interfacing with parameters and results through method attributes instead of bulky dictionaries
-- Stability of the half step Fourier method, allowing to use a soliton solution as an original state for the LLE 
+- Stability of the half step Fourier method, allowing to use a soliton solution as an original state for the LLE
 - Allowing arbitrary number of driving pump, according to Taheri et al The European Physical Journal D 2017. and our paper on Nature Communication (Moille et al. Nature Communication 2021)
-- Julia compatibility with version 1.1 and above 
+- Julia compatibility with version 1.1 and above
 
 ## How to Cite Us?
 
@@ -35,9 +35,9 @@ You can cite our paper published in the Journal of Research of National Institut
 As pyLLE relies on a Julia back-end, please prior to installing this package be sure that Julia is installed on your machine or visit the julia [package download page](https://julialang.org/downloads/) to install it. The code should now work with any recent version of Julia.
 
 
-**Windows users**: Please, keep julia in the default directory during the installation (i.e. ~\AppData\Local\Julia-1.1.1\ for windows).
+**Windows users**: During installation, check the option to **add julia to the path**.
 
-**Mac Os User**: You would need to add the julia binary to the path. The easiest way to do it is to create a simlink in the terminal
+**Mac Os User**: You need to add the julia binary to the path. The easiest way to do it is to create a simlink in the terminal
 
 ```bash
 ln -s /Applications/Julia-<version>.app/Contents/Resources/julia/bin/julia /usr/local/bin/julia
@@ -49,10 +49,7 @@ For a automatic install, just pip it :
 ```bash
 pip install pyLLE
 ```
-For a manual install, download the .zip of the repository or clone it and install with the setup.py script
-
-
-If the julia location is custom, please before installing change in the setup.py, line 18 to the correct location, as in pyLLE/llesolver.py line 430 to point to the correct location. Thanks
+For a manual install, download the .zip of the repository or clone it and install with the setup.py script. 
 
 
 ## Checking that everything works correctly
@@ -84,10 +81,10 @@ then
 
 ## Example [![NBviewer](https://custom-icon-badges.demolab.com/badge/jupyter-notebook-blue.svg?logo=eye&logoColor=white)](https://nbviewer.org/github/gregmoille/pyLLE/blob/master/example/TemporalDualPump.ipynb)
 
-A complete example is available in the example directory [notebook](https://github.com/gregmoille/pyLLE/blob/master/example/TemporalDualPump.ipynb) with the corresponding file needed in the folder. 
-You can also access the [nbviewer](https://nbviewer.org/github/gregmoille/pyLLE/blob/master/example/TemporalDualPump.ipynb) example to have a better idea of what's going on: 
+A complete example is available in the example directory [notebook](https://github.com/gregmoille/pyLLE/blob/master/example/TemporalDualPump.ipynb) with the corresponding file needed in the folder.
+You can also access the [nbviewer](https://nbviewer.org/github/gregmoille/pyLLE/blob/master/example/TemporalDualPump.ipynb) example to have a better idea of what's going on:
 
-## Works Using pyLLE 
+## Works Using pyLLE
 
 If you want to be featured here, shoot me an email! I try to keep it up to date but this is not a priority, yet I would love to hear anybody who uses it!
 

--- a/pyLLE/_llesolver.py
+++ b/pyLLE/_llesolver.py
@@ -463,7 +463,7 @@ class LLEsolver(object):
         self._sim['FSR_center'] = self._analyze.D1[-1]/(2*np.pi)
 
 
-        
+
         if not "DKS_init" in self._sim.keys():
             self._sim['DKS_init']= np.zeros(self._analyze.Dint_sim[0].size)
 
@@ -669,7 +669,7 @@ class LLEsolver(object):
 
 
 
-                    
+
             for key, it in self._res.items():
                 if not key == 'domega_disp':
                     if type(it) is str:
@@ -726,12 +726,14 @@ class LLEsolver(object):
 
         def LaunchJulia():
 
-            if sys.platform == 'darwin':
-                julia = 'julia'
-            if sys.platform == 'linux2' or sys.platform == 'linux':
-                julia = 'julia'
-            if sys.platform == 'win32':
-                julia = os.path.expanduser('~') + '\\AppData\\Local\\Julia-1.1.1\\bin\\julia.exe'
+            julia = 'julia'
+
+            try:
+                self.JuliaSolver = sub.Popen(julia, stdout=sub.PIPE, stderr=sub.PIPE)
+            except:
+                raise ValueError('julia is not installed on the system path. ',
+                                 'Please add julia to the path or re-install ',
+                                 'and check the option to add to path.')
 
             command = [julia, path_juliaScript , self.tmp_dir, str(tol), str(maxiter), str(step_factor)]
             self.JuliaSolver = sub.Popen(command, stdout=sub.PIPE, stderr=sub.PIPE)
@@ -957,7 +959,7 @@ class LLEsolver(object):
             self._sol['kappa_ext'] = S["Results/kappa_extReal"][:]
             self._sol['kappa0'] = S["Results/kappa_0Real"][:]
 
-        
+
         os.remove(self.tmp_dir + 'ParamLLEJulia.h5')
         os.remove(self.tmp_dir + 'ResultsJulia.h5')
 


### PR DESCRIPTION
Hi Greg,

Thanks again for your great work on this!

It took me a little while to get the example notebook running today, because I am on windows with Julia 1.8.0 and the Julia path was hardcoded to

```python
julia = os.path.expanduser('~') + '\\AppData\\Local\\Julia-1.1.1\\bin\\julia.exe'
```

but I had julia installed at:
```
C:\Users\DanielHickstein\AppData\Local\Programs\Julia-1.8.0\bin\julia.exe
```
(version number is different, and "Programs" directory is new). The error was confusing: `FileNotFoundError: [WinError 2] The system cannot find the file specified`, so it took me a while to even realize that was going wrong. 

When I installed Julia on windows, there is an option in the installed to include Julia on the path. So, perhaps it's easier to change the readme to ask the user to add Julia to the path for all systems (already required on MacOS and Linux) and just set

```python
julia = 'julia'
```

for all systems. 

I also included a try/except block to check to see if python can successfully call Julia, and raise a more helpful error message if it cannot. I imagine that this will be a fairly common scenario for new users.

Also, I couldn't figure what the following code-block in the `setup.py` is doing. It doesn't seem to be executing when I install pyLLE, so perhaps it can be removed:

```python
class MyInstall(install):
    def run(self):
        install.run(self)
        for ii in range(20):
            print('-'*10)
        if sys.platform == 'darwin':
            julia = 'julia'
        if sys.platform == 'linux2':
            julia = 'julia'
        if sys.platform == 'win32':
            julia = os.path.expanduser('~') + '\\AppData\\Local\\Julia-1.1.1\\bin\\julia.exe'
        sub.call([julia, 'InstallPkg.jl'])
```


