### PR TITLE
allow pyType to work with spyder

### DIFF
--- a/pyLLE/_llesolver.py
+++ b/pyLLE/_llesolver.py
@@ -62,11 +62,11 @@ try:
         pyType = 'jupyter'
     elif className == 'TerminalInteractiveShell':
         pyType = 'ipython'
+    else:
+        pyType = 'normal'
 except:
     # launching trhough a normal python
     pyType = 'normal'
-
-# print(pyType)
 
 
 class MyLogger():


### PR DESCRIPTION
When running in Spyder, get_ipython().__class__.__name__ returns "SpyderShell", so we need to account for this and set pyType to "normal" in this case.